### PR TITLE
using interrupt for uart scheduling and queue for transport and parsing instead of an array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rp-pico = "0.7"
 critical-section = "1.1.1"
 fugit = "0.3.6"
 heapless = "0.7.16"
+bbqueue = { version =" 0.5.1", features = ["thumbv6"]}
 
 # but you can use any BSP. Uncomment this to use the pro_micro_rp2040 BSP instead
 # sparkfun-pro-micro-rp2040 = "0.6"

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,12 @@ fn main() -> ! {
 
     let mut servo = Servo::new(channel, SERVO_DUTY_ON_ZERO);
 
+    unsafe {
+        // Enable the UART interrupt in the *Nested Vectored Interrupt
+        // Controller*, which is part of the Cortex-M0+ core.
+        pac::NVIC::unmask(pac::Interrupt::UART0_IRQ);
+    }
+
     // TODO fix blocking while buffer isn`t full
     core1
         .spawn(unsafe { &mut CORE1_STACK.mem }, move || {
@@ -166,7 +172,6 @@ fn main() -> ! {
 
             loop {
                 cortex_m::asm::wfe();
-
                 unsafe {
                     for data in DATA_Q.into_iter() {
                         let _ = tx.write(*data);

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,7 +222,7 @@ fn UART0_IRQ() {
     // Check if we have a UART to work with
     if let Some(reader) = READER {
         while let Ok(byte) = reader.read() {
-            if let Err(_) = producer.enqueue(byte) {
+            if producer.enqueue(byte).is_err() {
                 break;
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,7 +3,7 @@
 use crate::drivers::stepper_with_driver::Direction;
 use heapless::spsc::{Consumer, Queue};
 
-pub const MESSAGE_BUFFER_SIZE: usize = 5;
+pub const MESSAGE_BUFFER_SIZE: usize = 8;
 
 #[derive(PartialEq)]
 pub enum Message {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -37,7 +37,7 @@ impl<'a, T: Write<u8>> UnitTest<'a, T> {
         let (mut producer, mut consumer) = queue.split();
 
         for byte in data {
-            if let Err(_) = producer.enqueue(*byte) {
+            if producer.enqueue(*byte).is_err() {
                 break;
             }
         }


### PR DESCRIPTION
This allows to use messages with different length
It still needs cleaning though